### PR TITLE
F #6: Adds tilt-provider.yaml for being able to debug with tilt

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"k8s.io/klog/v2"
+
 	infrav1 "github.com/OpenNebula/cluster-api-provider-opennebula/api/v1beta1"
 	controllers "github.com/OpenNebula/cluster-api-provider-opennebula/internal/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +63,8 @@ func init() {
 }
 
 func main() {
+	klog.InitFlags(nil)
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string

--- a/tilt-provider.yaml
+++ b/tilt-provider.yaml
@@ -1,0 +1,6 @@
+name: opennebula-infrastructure
+config:
+  image: "ghcr.io/opennebula/cluster-api-provider-opennebula"
+  live_reload_deps: ["cmd/main.go", "go.mod", "go.sum", "api", "cmd", "internal", "config", "pkg"]
+  go_main: cmd/main.go
+  label: CAPONE


### PR DESCRIPTION
In that way, we can call tilt from the [cluster api repo](https://github.com/kubernetes-sigs/cluster-api/blob/main/Makefile#L994) and debug the one cluster api provider.

Also, adds [log verbosity](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use) flags for the provider.

Documentation added in wiki: [preview](https://github.com/aleixrm/cluster-api-provider-opennebula/wiki/dev_tilt) -> aleixrm/cluster-api-provider-opennebula.wiki.git:f-6/adds-tilt-debugging-docs

Closes #6 