### PR TITLE
B #30: Allows to define VR HAProxy listener ports

### DIFF
--- a/api/v1beta1/onecluster_types.go
+++ b/api/v1beta1/onecluster_types.go
@@ -59,6 +59,9 @@ type ONEVirtualRouter struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// +optional
+	ListenerPorts []int32 `json:"listenerPorts,omitempty"`
+
+	// +optional
 	ExtraContext map[string]string `json:"extraContext,omitempty"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oneclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oneclusters.yaml
@@ -120,6 +120,11 @@ spec:
                     type: integer
                   templateName:
                     type: string
+                  listenerPorts:
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                 required:
                 - templateName
                 type: object

--- a/internal/cloud/machine.go
+++ b/internal/cloud/machine.go
@@ -19,12 +19,15 @@ package cloud
 import (
 	"encoding/base64"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 
 	infrav1 "github.com/OpenNebula/cluster-api-provider-opennebula/api/v1beta1"
 
 	goca "github.com/OpenNebula/one/src/oca/go/src/goca"
 	goca_vm "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
+	goca_vm_keys "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm/keys"
 )
 
 type Machine struct {
@@ -143,18 +146,35 @@ func (m *Machine) FromTemplate(templateName string, userData *string, network *i
 
 	if router != nil {
 		// Mark this machine as a Control-Plane backend in the VR (dynamic LB).
-		update := goca_vm.NewTemplate()
-		update.Add("ONEGATE_HAPROXY_LB0_IP", "<ETH0_EP0>")
-		update.Add("ONEGATE_HAPROXY_LB0_PORT", "6443")
-		update.Add("ONEGATE_HAPROXY_LB0_SERVER_HOST", m.Address4)
-		update.Add("ONEGATE_HAPROXY_LB0_SERVER_PORT", "6443")
-
+		update := generateVMTemplateVRouterLBParams(router, m.Address4)
 		if err := m.ctrl.VM(m.ID).Update(update.String(), 1); err != nil {
 			return fmt.Errorf("Failed to update VM: %w", err)
 		}
 	}
 
 	return nil
+}
+
+func generateVMTemplateVRouterLBParams(router *infrav1.ONEVirtualRouter, serverAddress string) *goca_vm.Template {
+	update := goca_vm.NewTemplate()
+	if len(router.ListenerPorts) == 0 {
+		//defaults to kubernetes api port load balancing
+		update.Add("ONEGATE_HAPROXY_LB0_IP", "<ETH0_EP0>")
+		update.Add("ONEGATE_HAPROXY_LB0_PORT", "6443")
+		update.Add("ONEGATE_HAPROXY_LB0_SERVER_HOST", serverAddress)
+		update.Add("ONEGATE_HAPROXY_LB0_SERVER_PORT", "6443")
+		return update
+	}
+
+	slices.Sort(router.ListenerPorts)
+	for idx, port := range router.ListenerPorts {
+		//NOTE: Pass ports as strings, as the template make pair method doesn't support int32 values
+		update.Add(goca_vm_keys.Template(fmt.Sprintf("ONEGATE_HAPROXY_LB%d_IP", idx)), "<ETH0_EP0>")
+		update.Add(goca_vm_keys.Template(fmt.Sprintf("ONEGATE_HAPROXY_LB%d_PORT", idx)), strconv.Itoa(int(port)))
+		update.Add(goca_vm_keys.Template(fmt.Sprintf("ONEGATE_HAPROXY_LB%d_SERVER_HOST", idx)), serverAddress)
+		update.Add(goca_vm_keys.Template(fmt.Sprintf("ONEGATE_HAPROXY_LB%d_SERVER_PORT", idx)), strconv.Itoa(int(port)))
+	}
+	return update
 }
 
 func (m *Machine) Delete() error {

--- a/kustomize/v1beta1/rke2-dev/cluster-template.yaml
+++ b/kustomize/v1beta1/rke2-dev/cluster-template.yaml
@@ -119,6 +119,7 @@ spec:
     name: "${PRIVATE_NETWORK_NAME}"
   virtualRouter:
     templateName: "${ROUTER_TEMPLATE_NAME}"
+    listenerPorts: [6443, 9345]
     extraContext: {}
   images:
     - imageName: "${ROUTER_TEMPLATE_NAME}"

--- a/kustomize/v1beta1/rke2/cluster-template.yaml
+++ b/kustomize/v1beta1/rke2/cluster-template.yaml
@@ -119,6 +119,7 @@ spec:
     name: "${PRIVATE_NETWORK_NAME}"
   virtualRouter:
     templateName: "${ROUTER_TEMPLATE_NAME}"
+    listenerPorts: [6443, 9345]
     extraContext: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
In that way, we can expose and load balance multiple ports from the VRouter. This is necessary for instance for exposing the RKE2 server port (9345) and let the rke2 agents connect to the server nodes through the Virtual Router Load Balancer using the registrationMethod: "address" field. More info: https://caprke2.docs.rancher.com/02_topics/02_node-registration-methods.html 

Closes #30 