### PR TITLE
B #35: Fix multiple problems related to cluster pivot operations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 _artifacts/
+_backups/
 _releases/
 bin/
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 
 _artifacts/
+_backups/
 _releases/
 bin/
 .env

--- a/config/crd-dev/kustomization.yaml
+++ b/config/crd-dev/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../crd/
+
+labels:
+- pairs:
+    clusterctl.cluster.x-k8s.io: ""

--- a/config/default-dev/kustomization.yaml
+++ b/config/default-dev/kustomization.yaml
@@ -1,0 +1,19 @@
+namespace: capone-system
+
+namePrefix: capone-
+
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: infrastructure-opennebula
+
+resources:
+- ../crd-dev
+- ../rbac
+- ../manager
+- metrics_service.yaml
+
+patches:
+- path: manager_metrics_patch.yaml
+  target:
+    kind: Deployment

--- a/config/default-dev/manager_metrics_patch.yaml
+++ b/config/default-dev/manager_metrics_patch.yaml
@@ -1,0 +1,4 @@
+# This patch adds the args to allow exposing the metrics endpoint using HTTPS
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8443

--- a/config/default-dev/metrics_service.yaml
+++ b/config/default-dev/metrics_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: cluster-api-provider-opennebula
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager

--- a/internal/cloud/images.go
+++ b/internal/cloud/images.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	goca "github.com/OpenNebula/one/src/oca/go/src/goca"
-	img "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/image"
+	goca_image "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/image"
 )
 
 type Images struct {
@@ -52,13 +52,16 @@ func (i *Images) ImageReady(imageName string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("Failed to find Image template: %s, %w", imageName, err)
 	}
+
 	image, err := i.ctrl.Image(existingImageID).Info(true)
 	if err != nil {
 		return false, fmt.Errorf("Failed to get Image info: %w", err)
 	}
+
 	state, err := image.State()
 	if err != nil {
 		return false, fmt.Errorf("Failed to get Image state: %w", err)
 	}
-	return state == img.Ready || state == img.Used, nil
+
+	return state == goca_image.Ready || state == goca_image.Used, nil
 }

--- a/internal/cloud/templates.go
+++ b/internal/cloud/templates.go
@@ -35,14 +35,16 @@ func NewTemplates(cc *Clients, clusterUID string) *Templates {
 }
 
 func (t *Templates) CreateTemplate(templateName, templateContent string) error {
+	templateClusterUID := fmt.Sprintf("%s-%s", templateName, t.clusterUID)
+
 	existingID, err := t.ctrl.Templates().ByName(templateName)
 	if err != nil && err.Error() != "resource not found" {
 		return err
 	}
 
 	createNew := existingID < 0
-	templateClusterUID := templateName + "-" + t.clusterUID
-	if existingID >= 0 {
+
+	if !createNew {
 		vmTemplate, err := t.ctrl.Template(existingID).Info(false, true)
 		if err != nil {
 			return fmt.Errorf("Failed to obtain existing VM template: %w", err)
@@ -56,6 +58,7 @@ func (t *Templates) CreateTemplate(templateName, templateContent string) error {
 			createNew = true
 		}
 	}
+
 	if createNew {
 		templateSpec := fmt.Sprintf(
 			"NAME = \"%s\"\nCLUSTER_UID = \"%s\"\n%s",


### PR DESCRIPTION
- Update clusterctl to v1.9.6
- Add support for multiple workload clusters in the Makefile
- Add one-backup and one-restore recipes
- Add missing clusterctl-init-rke2 recipe (fix)
- Add correct kube-flannel.yml path in the one-flannel recipe (fix)
- Add crd-dev and default-dev config scripts
- Add missing pause logic in the cluster controller (fix)
- Refactor image readiness loop (fix)
- Mark cluster ready if VR is not defined (fix)
- Make minor coding style improvements
- Update .gitignore and .dockerignore