### PR TITLE
F #53: Adds image datastore option

### DIFF
--- a/api/v1beta1/onecluster_types.go
+++ b/api/v1beta1/onecluster_types.go
@@ -96,6 +96,9 @@ type ONEImage struct {
 
 	// +required
 	ImageContent string `json:"imageContent,omitempty"`
+
+	// +optional
+	ImageDatastoreId *uint `json:"imageDatastoreId,omitempty"`
 }
 
 // ONEClusterStatus defines the observed state of ONECluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oneclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oneclusters.yaml
@@ -60,6 +60,10 @@ spec:
                       type: string
                     imageName:
                       type: string
+                    imageDatastoreId:
+                      format: int32
+                      type: integer
+                      default: 1
                   required:
                   - imageContent
                   - imageName

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	k8s.io/apimachinery v0.31.3
 	k8s.io/client-go v0.31.3
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/cluster-api v1.9.5
 	sigs.k8s.io/cluster-api/test v1.9.5
 	sigs.k8s.io/controller-runtime v0.19.6
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -151,10 +153,8 @@ require (
 	k8s.io/cluster-bootstrap v0.31.3 // indirect
 	k8s.io/component-base v0.31.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.25.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/internal/cloud/images.go
+++ b/internal/cloud/images.go
@@ -35,7 +35,7 @@ func NewImages(clients *Clients) (*Images, error) {
 	return &Images{ctrl: goca.NewController(clients.RPC2)}, nil
 }
 
-func (i *Images) CreateImage(imageName, imageContent string) error {
+func (i *Images) CreateImage(imageName, imageContent string, datastoreId uint) error {
 	existingImageID, err := i.ctrl.Images().ByName(imageName)
 	if err != nil && err.Error() != "resource not found" {
 		return err
@@ -43,7 +43,7 @@ func (i *Images) CreateImage(imageName, imageContent string) error {
 
 	if existingImageID < 0 {
 		imageSpec := fmt.Sprintf("NAME = \"%s\"\n%s", imageName, imageContent)
-		if _, err = i.ctrl.Images().Create(imageSpec, 1); err != nil {
+		if _, err = i.ctrl.Images().Create(imageSpec, datastoreId); err != nil {
 			return fmt.Errorf("Failed to create image: %w", err)
 		}
 	}

--- a/internal/controller/onecluster_controller.go
+++ b/internal/controller/onecluster_controller.go
@@ -166,9 +166,14 @@ func (r *ONEClusterReconciler) reconcileNormal(
 		imagesReady := true
 		for _, image := range oneCluster.Spec.Images {
 			if image.ImageName != "" && image.ImageContent != "" {
+				if image.ImageDatastoreId == nil {
+					//default value is set in the CRD openapi spec
+					return ctrl.Result{}, fmt.Errorf("image %s has no datastore ID set", image.ImageName)
+				}
 				if err := externalImages.CreateImage(
 					image.ImageName,
 					image.ImageContent,
+					*image.ImageDatastoreId,
 				); err != nil {
 					return ctrl.Result{}, errors.Wrap(err, "failed to create images")
 				}

--- a/kustomize/v1beta1/rke2-dev/cluster-template.yaml
+++ b/kustomize/v1beta1/rke2-dev/cluster-template.yaml
@@ -124,7 +124,7 @@ spec:
   images:
     - imageName: "${ROUTER_TEMPLATE_NAME}"
       imageContent: |
-        PATH = "https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-6.10.0-3-20250424.qcow2"
+        PATH = "https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-7.0.0-0-20250528.qcow2"
         DEV_PREFIX = "vd"
     - imageName: "${MASTER_TEMPLATE_NAME}"
       imageContent: |


### PR DESCRIPTION
* Adds `imageDatastoreId` attribute to cluster CRD -> defaults to 1
* Updates rke2 tests vrouter image to 7.0

Closes https://github.com/OpenNebula/cluster-api-provider-opennebula/issues/53
