### PR TITLE
B #55: Adds MachineHealthChecks for node self-healing

### DIFF
--- a/helm/v1beta1/capone-rke2/values.yaml
+++ b/helm/v1beta1/capone-rke2/values.yaml
@@ -17,7 +17,7 @@ WORKER_TEMPLATE_NAME: "{{ .Release.Name }}-worker"
 CLUSTER_IMAGES:
   - imageName: "{{ .Release.Name }}-router"
     imageContent: |
-      PATH = "https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-6.10.0-3-20250424.qcow2"
+      PATH = "https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-7.0.0-0-20250528.qcow2"
       DEV_PREFIX = "vd"
   - imageName: "{{ .Release.Name }}-node"
     imageContent: |

--- a/kustomize/v1beta1/default-dev/cluster-template.yaml
+++ b/kustomize/v1beta1/default-dev/cluster-template.yaml
@@ -350,3 +350,42 @@ stringData:
               effect: NoSchedule
           nodeSelector:
             node-role.kubernetes.io/control-plane: ""
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-cp-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  nodeStartupTimeout: 15m
+  maxUnhealthy: 1
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: "${CLUSTER_NAME}-md-0"
+  nodeStartupTimeout: 15m
+  # Prevent mass replacements: absolute number or percentage
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m

--- a/kustomize/v1beta1/default-vip/cluster-template.yaml
+++ b/kustomize/v1beta1/default-vip/cluster-template.yaml
@@ -396,3 +396,42 @@ stringData:
               effect: NoSchedule
           nodeSelector:
             node-role.kubernetes.io/control-plane: ""
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-cp-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  nodeStartupTimeout: 15m
+  maxUnhealthy: 1
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: "${CLUSTER_NAME}-md-0"
+  nodeStartupTimeout: 15m
+  # Prevent mass replacements: absolute number or percentage
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m

--- a/kustomize/v1beta1/default/cluster-template.yaml
+++ b/kustomize/v1beta1/default/cluster-template.yaml
@@ -274,3 +274,42 @@ stringData:
               effect: NoSchedule
           nodeSelector:
             node-role.kubernetes.io/control-plane: ""
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-cp-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  nodeStartupTimeout: 15m
+  maxUnhealthy: 1
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: "${CLUSTER_NAME}-md-0"
+  nodeStartupTimeout: 15m
+  # Prevent mass replacements: absolute number or percentage
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m

--- a/kustomize/v1beta1/rke2-dev/cluster-template.yaml
+++ b/kustomize/v1beta1/rke2-dev/cluster-template.yaml
@@ -339,3 +339,42 @@ stringData:
               effect: NoSchedule
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-cp-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  nodeStartupTimeout: 15m
+  maxUnhealthy: 1
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: "${CLUSTER_NAME}-md-0"
+  nodeStartupTimeout: 15m
+  # Prevent mass replacements: absolute number or percentage
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m

--- a/kustomize/v1beta1/rke2-vip/cluster-template.yaml
+++ b/kustomize/v1beta1/rke2-vip/cluster-template.yaml
@@ -400,3 +400,42 @@ spec:
   controlPlaneEndpoint:
     host: "${CONTROL_PLANE_HOST}"
     port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-cp-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  nodeStartupTimeout: 15m
+  maxUnhealthy: 1
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: "${CLUSTER_NAME}-md-0"
+  nodeStartupTimeout: 15m
+  # Prevent mass replacements: absolute number or percentage
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m

--- a/kustomize/v1beta1/rke2/cluster-template.yaml
+++ b/kustomize/v1beta1/rke2/cluster-template.yaml
@@ -55,6 +55,9 @@ spec:
     rollingUpdate:
       maxSurge: 1
   registrationMethod: "internal-first"
+  remediationStrategy:
+    maxRetry: 3
+    retryPeriod: 5m
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ONEMachineTemplate
@@ -268,3 +271,42 @@ stringData:
               effect: NoSchedule
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-cp-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  nodeStartupTimeout: 15m
+  maxUnhealthy: 1
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-mhc"
+spec:
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: "${CLUSTER_NAME}-md-0"
+  nodeStartupTimeout: 15m
+  # Prevent mass replacements: absolute number or percentage
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Ready
+    status: "False"
+    timeout: 5m
+  - type: Ready
+    status: "Unknown"
+    timeout: 5m


### PR DESCRIPTION
Adds `MachineHealtchCheck` objects for observing cluster API `Machine` status and mark them as Unhealthy in case a node is down.

Also updates vrouter image version for rke2 clusters.

More info: https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking 

Closes https://github.com/OpenNebula/cluster-api-provider-opennebula/issues/55

Related issue that needs further investigation: https://github.com/OpenNebula/cluster-api-provider-opennebula/issues/61